### PR TITLE
Add or update the Azure App Service build and deployment workflow config

### DIFF
--- a/.github/workflows/publish-to-azure_dev-helseid-demo-fhi.yml
+++ b/.github/workflows/publish-to-azure_dev-helseid-demo-fhi.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up .NET Core
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.x'
+          dotnet-version: '9.x'
 
       - name: Build with dotnet
         run: dotnet build --configuration Release

--- a/.github/workflows/publish-to-azure_dev-helseid-demo-fhi.yml
+++ b/.github/workflows/publish-to-azure_dev-helseid-demo-fhi.yml
@@ -6,7 +6,7 @@ name: Build and deploy ASP.Net Core app to Azure Web App - Dev-HelseId-Demo-Fhi
 on:
   push:
     branches:
-      - main
+      - publish-to-azure
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/publish-to-azure_dev-helseid-demo-fhi.yml
+++ b/.github/workflows/publish-to-azure_dev-helseid-demo-fhi.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up .NET Core
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.x'
+          dotnet-version: '9.x'
 
       - name: Build with dotnet
         run: dotnet build MyWebApp/MyWebApp.Server/MyWebApp.Server.csproj --configuration Release

--- a/.github/workflows/publish-to-azure_dev-helseid-demo-fhi.yml
+++ b/.github/workflows/publish-to-azure_dev-helseid-demo-fhi.yml
@@ -6,7 +6,7 @@ name: Build and deploy ASP.Net Core app to Azure Web App - dev-helseid-demo-fhi
 on:
   push:
     branches:
-      - publish-to-azure
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/publish-to-azure_dev-helseid-demo-fhi.yml
+++ b/.github/workflows/publish-to-azure_dev-helseid-demo-fhi.yml
@@ -17,21 +17,22 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up .NET Core
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '8.x'
+          dotnet-version: '9.x'
+          include-prerelease: true
 
       - name: Build with dotnet
         run: dotnet build MyWebApp/MyWebApp.Server/MyWebApp.Server.csproj --configuration Release
 
       - name: dotnet publish
-        run: dotnet publish MyWebApp/MyWebApp.Server/MyWebApp.Server.csproj -c Release -o ${{env.DOTNET_ROOT}}\myapp
+        run: dotnet publish MyWebApp/MyWebApp.Server/MyWebApp.Server.csproj -c Release -o ${{env.DOTNET_ROOT}}/myapp
 
       - name: Upload artifact for deployment job
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: .net-app
-          path: ${{env.DOTNET_ROOT}}\myapp
+          path: ${{env.DOTNET_ROOT}}/myapp
 
   deploy:
     runs-on: windows-latest
@@ -48,7 +49,7 @@ jobs:
       
       - name: Deploy to Azure Web App
         id: deploy-to-webapp
-        uses: azure/webapps-deploy@v3
+        uses: azure/webapps-deploy@v2
         with:
           app-name: 'Dev-HelseId-Demo-Fhi'
           slot-name: 'Production'

--- a/.github/workflows/publish-to-azure_dev-helseid-demo-fhi.yml
+++ b/.github/workflows/publish-to-azure_dev-helseid-demo-fhi.yml
@@ -19,13 +19,13 @@ jobs:
       - name: Set up .NET Core
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '9.x'
+          dotnet-version: '8.x'
 
       - name: Build with dotnet
-        run: dotnet build --configuration Release
+        run: dotnet build MyWebApp/MyWebApp.Server/MyWebApp.Server.csproj --configuration Release
 
       - name: dotnet publish
-        run: dotnet publish -c Release -o ${{env.DOTNET_ROOT}}/myapp
+        run: dotnet publish MyWebApp/MyWebApp.Server/MyWebApp.Server.csproj -c Release -o ${{env.DOTNET_ROOT}}/myapp
 
       - name: Upload artifact for deployment job
         uses: actions/upload-artifact@v4

--- a/.github/workflows/publish-to-azure_dev-helseid-demo-fhi.yml
+++ b/.github/workflows/publish-to-azure_dev-helseid-demo-fhi.yml
@@ -1,7 +1,7 @@
 # Docs for the Azure Web Apps Deploy action: https://github.com/Azure/webapps-deploy
 # More GitHub Actions for Azure: https://github.com/Azure/actions
 
-name: Build and deploy ASP.Net Core app to Azure Web App - Dev-HelseId-Demo-Fhi
+name: Build and deploy ASP.Net Core app to Azure Web App - dev-helseid-demo-fhi
 
 on:
   push:
@@ -19,14 +19,14 @@ jobs:
       - name: Set up .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '9.x'
+          dotnet-version: '8.x'
           include-prerelease: true
 
       - name: Build with dotnet
-        run: dotnet build MyWebApp/MyWebApp.Server/MyWebApp.Server.csproj --configuration Release
+        run: dotnet build --configuration Release
 
       - name: dotnet publish
-        run: dotnet publish MyWebApp/MyWebApp.Server/MyWebApp.Server.csproj -c Release -o ${{env.DOTNET_ROOT}}/myapp
+        run: dotnet publish -c Release -o ${{env.DOTNET_ROOT}}/myapp
 
       - name: Upload artifact for deployment job
         uses: actions/upload-artifact@v3
@@ -40,18 +40,18 @@ jobs:
     environment:
       name: 'Production'
       url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}
-    
+
     steps:
       - name: Download artifact from build job
         uses: actions/download-artifact@v3
         with:
           name: .net-app
-      
+
       - name: Deploy to Azure Web App
         id: deploy-to-webapp
         uses: azure/webapps-deploy@v2
         with:
-          app-name: 'Dev-HelseId-Demo-Fhi'
+          app-name: 'dev-helseid-demo-fhi'
           slot-name: 'Production'
+          publish-profile: ${{ secrets.AZUREAPPSERVICE_PUBLISHPROFILE_D15514B31155454D8DAE9FB4E6A08BAA }}
           package: .
-          publish-profile: ${{ secrets.AZUREAPPSERVICE_PUBLISHPROFILE_B443C4E08DC645FA863DCE4D0634DFDE }}

--- a/.github/workflows/publish-to-azure_dev-helseid-demo-fhi.yml
+++ b/.github/workflows/publish-to-azure_dev-helseid-demo-fhi.yml
@@ -43,7 +43,7 @@ jobs:
     
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: .net-app
       

--- a/.github/workflows/publish-to-azure_dev-helseid-demo-fhi.yml
+++ b/.github/workflows/publish-to-azure_dev-helseid-demo-fhi.yml
@@ -19,14 +19,14 @@ jobs:
       - name: Set up .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '8.x'
+          dotnet-version: '9.x'
           include-prerelease: true
 
       - name: Build with dotnet
-        run: dotnet build --configuration Release
+        run: dotnet build MyWebApp/MyWebApp.Server/MyWebApp.Server.csproj --configuration Release
 
       - name: dotnet publish
-        run: dotnet publish -c Release -o ${{env.DOTNET_ROOT}}/myapp
+        run: dotnet publish MyWebApp/MyWebApp.Server/MyWebApp.Server.csproj -c Release -o ${{env.DOTNET_ROOT}}/myapp
 
       - name: Upload artifact for deployment job
         uses: actions/upload-artifact@v3

--- a/.github/workflows/publish-to-azure_dev-helseid-demo-fhi.yml
+++ b/.github/workflows/publish-to-azure_dev-helseid-demo-fhi.yml
@@ -1,0 +1,56 @@
+# Docs for the Azure Web Apps Deploy action: https://github.com/Azure/webapps-deploy
+# More GitHub Actions for Azure: https://github.com/Azure/actions
+
+name: Build and deploy ASP.Net Core app to Azure Web App - Dev-HelseId-Demo-Fhi
+
+on:
+  push:
+    branches:
+      - publish-to-azure
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up .NET Core
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.x'
+
+      - name: Build with dotnet
+        run: dotnet build --configuration Release
+
+      - name: dotnet publish
+        run: dotnet publish -c Release -o ${{env.DOTNET_ROOT}}/myapp
+
+      - name: Upload artifact for deployment job
+        uses: actions/upload-artifact@v4
+        with:
+          name: .net-app
+          path: ${{env.DOTNET_ROOT}}/myapp
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: 'Production'
+      url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}
+    
+    steps:
+      - name: Download artifact from build job
+        uses: actions/download-artifact@v4
+        with:
+          name: .net-app
+      
+      - name: Deploy to Azure Web App
+        id: deploy-to-webapp
+        uses: azure/webapps-deploy@v3
+        with:
+          app-name: 'Dev-HelseId-Demo-Fhi'
+          slot-name: 'Production'
+          package: .
+          publish-profile: ${{ secrets.AZUREAPPSERVICE_PUBLISHPROFILE_87E03AC3717F49AAAC2008CCB5EDE330 }}

--- a/.github/workflows/publish-to-azure_dev-helseid-demo-fhi.yml
+++ b/.github/workflows/publish-to-azure_dev-helseid-demo-fhi.yml
@@ -22,10 +22,10 @@ jobs:
           dotnet-version: '8.x'
 
       - name: Build with dotnet
-        run: dotnet build --configuration Release
+        run: dotnet build MyWebApp/MyWebApp.Server/MyWebApp.Server.csproj --configuration Release
 
       - name: dotnet publish
-        run: dotnet publish -c Release -o ${{env.DOTNET_ROOT}}/myapp
+        run: dotnet publish MyWebApp/MyWebApp.Server/MyWebApp.Server.csproj -c Release -o ${{env.DOTNET_ROOT}}/myapp
 
       - name: Upload artifact for deployment job
         uses: actions/upload-artifact@v4

--- a/.github/workflows/publish-to-azure_dev-helseid-demo-fhi.yml
+++ b/.github/workflows/publish-to-azure_dev-helseid-demo-fhi.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -19,13 +19,13 @@ jobs:
       - name: Set up .NET Core
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '9.x'
+          dotnet-version: '8.x'
 
       - name: Build with dotnet
-        run: dotnet build MyWebApp/MyWebApp.Server/MyWebApp.Server.csproj --configuration Release
+        run: dotnet build --configuration Release
 
       - name: dotnet publish
-        run: dotnet publish MyWebApp/MyWebApp.Server/MyWebApp.Server.csproj -c Release -o ${{env.DOTNET_ROOT}}/myapp
+        run: dotnet publish -c Release -o ${{env.DOTNET_ROOT}}/myapp
 
       - name: Upload artifact for deployment job
         uses: actions/upload-artifact@v4
@@ -34,7 +34,7 @@ jobs:
           path: ${{env.DOTNET_ROOT}}/myapp
 
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     needs: build
     environment:
       name: 'Production'
@@ -53,4 +53,4 @@ jobs:
           app-name: 'Dev-HelseId-Demo-Fhi'
           slot-name: 'Production'
           package: .
-          publish-profile: ${{ secrets.AZUREAPPSERVICE_PUBLISHPROFILE_87E03AC3717F49AAAC2008CCB5EDE330 }}
+          publish-profile: ${{ secrets.AZUREAPPSERVICE_PUBLISHPROFILE_B443C4E08DC645FA863DCE4D0634DFDE }}

--- a/.github/workflows/publish-to-azure_dev-helseid-demo-fhi.yml
+++ b/.github/workflows/publish-to-azure_dev-helseid-demo-fhi.yml
@@ -25,13 +25,13 @@ jobs:
         run: dotnet build MyWebApp/MyWebApp.Server/MyWebApp.Server.csproj --configuration Release
 
       - name: dotnet publish
-        run: dotnet publish MyWebApp/MyWebApp.Server/MyWebApp.Server.csproj -c Release -o ${{env.DOTNET_ROOT}}/myapp
+        run: dotnet publish MyWebApp/MyWebApp.Server/MyWebApp.Server.csproj -c Release -o ${{env.DOTNET_ROOT}}\myapp
 
       - name: Upload artifact for deployment job
         uses: actions/upload-artifact@v4
         with:
           name: .net-app
-          path: ${{env.DOTNET_ROOT}}/myapp
+          path: ${{env.DOTNET_ROOT}}\myapp
 
   deploy:
     runs-on: windows-latest

--- a/.github/workflows/publish-to-azure_dev-helseid-demo-fhi.yml
+++ b/.github/workflows/publish-to-azure_dev-helseid-demo-fhi.yml
@@ -6,7 +6,7 @@ name: Build and deploy ASP.Net Core app to Azure Web App - Dev-HelseId-Demo-Fhi
 on:
   push:
     branches:
-      - publish-to-azure
+      - main
   workflow_dispatch:
 
 jobs:

--- a/MyWebApp/MyWebApp.Server/MyWebApp.Server.csproj
+++ b/MyWebApp/MyWebApp.Server/MyWebApp.Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <SpaRoot>..\MyWebApp.Client</SpaRoot>

--- a/fhi.helseid.demo.sln
+++ b/fhi.helseid.demo.sln
@@ -5,17 +5,13 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "MyWebApp", "MyWebApp", "{6CD22EB3-46BE-4A06-B0A5-6499F739C859}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MyWebApp.Server", "MyWebApp\mywebapp.server\MyWebApp.Server.csproj", "{A7FB1242-86BB-49A2-8025-FE742D4D495A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MyWebApp.Server", "MyWebApp\MyWebApp.Server\MyWebApp.Server.csproj", "{A7FB1242-86BB-49A2-8025-FE742D4D495A}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MyApi", "MyApi\MyApi.csproj", "{B546E21F-5378-4EF1-97C8-348E1DCBE004}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MyWebApp2.Server", "MyWebApp2\MyWebApp2.Server\MyWebApp2.Server.csproj", "{062811D0-5CB9-4368-96AC-21FF3DBA7367}"
 EndProject
 Project("{54A90642-561A-4BB1-A94E-469ADEE60C69}") = "MyWebApp.Client", "MyWebApp\MyWebApp.Client\MyWebApp.Client.esproj", "{47475081-C65B-46D0-86B6-B676B08F1BEF}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Fhi.HelseId.Web", "..\fhi.helseid\Fhi.HelseId.Web\Fhi.HelseId.Web.csproj", "{1BC103E4-C8CE-4D25-AAB0-A322D70C153F}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Fhi.AuthControllers", "..\fhi.helseid\Fhi.AccountController\Fhi.AuthControllers.csproj", "{013DBE71-2260-489F-9A2C-43823F3E29BC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -41,14 +37,6 @@ Global
 		{47475081-C65B-46D0-86B6-B676B08F1BEF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{47475081-C65B-46D0-86B6-B676B08F1BEF}.Release|Any CPU.Build.0 = Release|Any CPU
 		{47475081-C65B-46D0-86B6-B676B08F1BEF}.Release|Any CPU.Deploy.0 = Release|Any CPU
-		{1BC103E4-C8CE-4D25-AAB0-A322D70C153F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{1BC103E4-C8CE-4D25-AAB0-A322D70C153F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{1BC103E4-C8CE-4D25-AAB0-A322D70C153F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{1BC103E4-C8CE-4D25-AAB0-A322D70C153F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{013DBE71-2260-489F-9A2C-43823F3E29BC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{013DBE71-2260-489F-9A2C-43823F3E29BC}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{013DBE71-2260-489F-9A2C-43823F3E29BC}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{013DBE71-2260-489F-9A2C-43823F3E29BC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Site: https://dev-helseid-demo-fhi.azurewebsites.net/

When using .net 9 you have to use a linux server in azure.
This caused a lot of issues when deploying.
Therefore I have set .net to 8 so that the deployment works to a windows machine.
In linux it wants to run it as a container, therefore I recommend that we use something like docker to create a container to publish when using a linux server.

Some of the errors:
- the wwwroot folder was empty
- error message stating it wanted to run it as a container but failed